### PR TITLE
fix bug with time.go

### DIFF
--- a/cmd/time.go
+++ b/cmd/time.go
@@ -47,7 +47,7 @@ var calculateTimeCmd = &cobra.Command{
 				layout = "2006-01-02"
 			}
 			if space == 1 {
-				layout = "2006-01-02 15:04"
+				layout = "2006-01-02 15:04:05"
 			}
 			currentTimer, err = time.Parse(layout, calculateTime)
 			if err != nil {


### PR DESCRIPTION
before:
# go run main.go time calc -c="2020-11-26 10:12:51" -d="3s"
2020/11/26 10:13:26 输出结果: 1970-01-01 08:00, 3
now:
# go run main.go time calc -c="2020-11-26 10:12:51" -d="3s"
2020/11/26 10:29:59 输出结果: 2020-11-26 10:12:54, 1606385574